### PR TITLE
Feature: User-based access to tasks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 type BasicCredential struct {
 	User     string
 	Password string
+	Admin    bool
 }
 
 type OidcAuth struct {

--- a/config/default-config.yaml
+++ b/config/default-config.yaml
@@ -32,6 +32,9 @@ Server:
   # If used, make sure to properly restrict access to the config file
   # (e.g. chmod 600 funnel.config.yml)
   # BasicAuth:
+  #   - User: admin
+  #     Password: oejf023moq
+  #     Admin: true
   #   - User: user1
   #     Password: abc123
   #   - User: user2

--- a/database/badger/new.go
+++ b/database/badger/new.go
@@ -37,6 +37,7 @@ func (db *Badger) Close() {
 }
 
 var taskKeyPrefix = []byte("tasks")
+var ownerKeyPrefix = []byte("owners")
 
 func taskKey(id string) []byte {
 	idb := []byte(id)
@@ -44,4 +45,16 @@ func taskKey(id string) []byte {
 	key = append(key, taskKeyPrefix...)
 	key = append(key, idb...)
 	return key
+}
+
+func ownerKey(id string) []byte {
+	idb := []byte(id)
+	key := make([]byte, 0, len(ownerKeyPrefix)+len(idb))
+	key = append(key, ownerKeyPrefix...)
+	key = append(key, idb...)
+	return key
+}
+
+func ownerKeyFromTaskKey(taskKey []byte) []byte {
+	return taskKey[:len(taskKeyPrefix)]
 }

--- a/database/boltdb/new.go
+++ b/database/boltdb/new.go
@@ -19,6 +19,9 @@ var TaskBucket = []byte("tasks")
 // task ID -> nil
 var TasksQueued = []byte("tasks-queued")
 
+// TaskOwner maps: task ID -> owner string
+var TaskOwner = []byte("tasks-owner")
+
 // TaskState maps: task ID -> state string
 var TaskState = []byte("tasks-state")
 
@@ -71,6 +74,7 @@ func (taskBolt *BoltDB) Init() error {
 	return taskBolt.db.Update(func(tx *bolt.Tx) error {
 		ensureBucket(tx, TaskBucket)
 		ensureBucket(tx, TasksQueued)
+		ensureBucket(tx, TaskOwner)
 		ensureBucket(tx, TaskState)
 		ensureBucket(tx, TasksLog)
 		ensureBucket(tx, ExecutorLogs)

--- a/database/datastore/events.go
+++ b/database/datastore/events.go
@@ -14,7 +14,7 @@ func (d *Datastore) WriteEvent(ctx context.Context, e *events.Event) error {
 	switch e.Type {
 
 	case events.Type_TASK_CREATED:
-		putKeys, putData := marshalTask(e.GetTask())
+		putKeys, putData := marshalTask(e.GetTask(), ctx)
 		_, err := d.client.PutMulti(ctx, putKeys, putData)
 		return err
 
@@ -62,7 +62,7 @@ func (d *Datastore) WriteEvent(ctx context.Context, e *events.Event) error {
 			}
 
 			task := &tes.Task{}
-			if err := unmarshalTask(task, props); err != nil {
+			if err := unmarshalTask(task, props, ctx); err != nil {
 				return err
 			}
 
@@ -80,7 +80,7 @@ func (d *Datastore) WriteEvent(ctx context.Context, e *events.Event) error {
 				return err
 			}
 
-			putKeys, putData := marshalTask(task)
+			putKeys, putData := marshalTask(task, ctx)
 			_, err = tx.PutMulti(putKeys, putData)
 			return err
 		})

--- a/database/datastore/props.go
+++ b/database/datastore/props.go
@@ -1,11 +1,13 @@
 package datastore
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
 	"cloud.google.com/go/datastore"
 	"github.com/ohsu-comp-bio/funnel/events"
+	"github.com/ohsu-comp-bio/funnel/server"
 	"github.com/ohsu-comp-bio/funnel/tes"
 )
 
@@ -88,6 +90,7 @@ type part struct {
 type task struct {
 	Id, CreationTime  string `datastore:",omitempty"` // nolint
 	State             int32
+	Owner             string
 	Name, Description string     `datastore:",noindex,omitempty"`
 	Executors         []executor `datastore:",noindex,omitempty"`
 	Inputs            []param    `datastore:",noindex,omitempty"`
@@ -122,10 +125,16 @@ type param struct {
 	Type                                  int32  `datastore:",noindex,omitempty"`
 }
 
-func marshalTask(t *tes.Task) ([]*datastore.Key, []interface{}) {
+func marshalTask(t *tes.Task, ctx context.Context) ([]*datastore.Key, []interface{}) {
+	owner := ""
+	if userInfo, ok := ctx.Value(server.UserInfoKey).(*server.UserInfo); ok {
+		owner = userInfo.Username
+	}
+
 	z := &task{
 		Id:           t.Id,
 		State:        int32(t.State),
+		Owner:        owner,
 		CreationTime: t.CreationTime,
 		Name:         t.Name,
 		Description:  t.Description,
@@ -197,11 +206,15 @@ func marshalTask(t *tes.Task) ([]*datastore.Key, []interface{}) {
 	return keys, data
 }
 
-func unmarshalTask(z *tes.Task, props datastore.PropertyList) error {
+func unmarshalTask(z *tes.Task, props datastore.PropertyList, ctx context.Context) error {
 	c := &task{}
 	err := datastore.LoadStruct(c, props)
 	if err != nil {
 		return err
+	}
+
+	if userInfo, ok := ctx.Value(server.UserInfoKey).(*server.UserInfo); ok && !userInfo.IsAccessible(c.Owner) {
+		return tes.ErrNotPermitted
 	}
 
 	z.Id = c.Id

--- a/database/datastore/tes.go
+++ b/database/datastore/tes.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"cloud.google.com/go/datastore"
+	"github.com/ohsu-comp-bio/funnel/server"
 	"github.com/ohsu-comp-bio/funnel/tes"
 	"golang.org/x/net/context"
 	"google.golang.org/api/iterator"
@@ -21,7 +22,7 @@ func (d *Datastore) GetTask(ctx context.Context, req *tes.GetTaskRequest) (*tes.
 	}
 
 	task := &tes.Task{}
-	if err := unmarshalTask(task, props); err != nil {
+	if err := unmarshalTask(task, props, ctx); err != nil {
 		return nil, err
 	}
 
@@ -84,6 +85,14 @@ func (d *Datastore) ListTasks(ctx context.Context, req *tes.ListTasksRequest) (*
 		q = q.Start(c)
 	}
 
+	if userInfo, ok := ctx.Value(server.UserInfoKey).(*server.UserInfo); ok && !userInfo.IsAdmin {
+		if userInfo.IsPublic {
+			q = q.FilterField("Owner", "=", "")
+		} else if userInfo.Username != "" {
+			q = q.FilterField("Owner", "=", userInfo.Username)
+		}
+	}
+
 	if req.State != tes.Unknown {
 		q = q.FilterField("State", "=", int32(req.State))
 	}
@@ -117,7 +126,7 @@ func (d *Datastore) ListTasks(ctx context.Context, req *tes.ListTasksRequest) (*
 
 	for _, props := range proplists {
 		task := &tes.Task{}
-		if err := unmarshalTask(task, props); err != nil {
+		if err := unmarshalTask(task, props, ctx); err != nil {
 			return nil, err
 		}
 

--- a/database/dynamodb/util.go
+++ b/database/dynamodb/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/ohsu-comp-bio/funnel/server"
 	"github.com/ohsu-comp-bio/funnel/tes"
 )
 
@@ -250,6 +251,12 @@ func (db *DynamoDB) createTask(ctx context.Context, task *tes.Task) error {
 
 	av["version"] = &dynamodb.AttributeValue{
 		S: aws.String(strconv.FormatInt(time.Now().UnixNano(), 10)),
+	}
+
+	if userInfo, ok := ctx.Value(server.UserInfoKey).(*server.UserInfo); ok && userInfo.Username != "" {
+		av["owner"] = &dynamodb.AttributeValue{
+			S: aws.String(userInfo.Username),
+		}
 	}
 
 	// Add nil fields to make updates easier

--- a/database/elastic/scheduler.go
+++ b/database/elastic/scheduler.go
@@ -31,8 +31,7 @@ func (es *Elastic) ReadQueue(n int) []*tes.Task {
 
 	var tasks []*tes.Task
 	for _, hit := range res.Hits.Hits {
-		t := &tes.Task{}
-		err := protojson.Unmarshal(*hit.Source, t)
+		t, err := unmarshalTask(*hit.Source)
 		if err != nil {
 			continue
 		}

--- a/docs/funnel-config-examples/default-config.yaml
+++ b/docs/funnel-config-examples/default-config.yaml
@@ -32,6 +32,9 @@ Server:
   # If used, make sure to properly restrict access to the config file
   # (e.g. chmod 600 funnel.config.yml)
   # BasicAuth:
+  #   - User: admin
+  #     Password: oejf023moq
+  #     Admin: true
   #   - User: user1
   #     Password: abc123
   #   - User: user2

--- a/server/auth.go
+++ b/server/auth.go
@@ -21,9 +21,17 @@ type Authentication struct {
 
 // Extracted info about the current user, which is exposed through Context.
 type UserInfo struct {
+	// Public users are non-authenticated, in case Funnel configuration does
+	// not require OIDC nor Basic authentication.
 	IsPublic bool
-	IsAdmin  bool
+	// Administrator is a Basic-authentication user with `Admin: true` property
+	// in the configuration file.
+	IsAdmin bool
+	// Username of an authenticated user (subject field from JWT).
 	Username string
+	// In case of OIDC authentication, the provided Bearer token, which can be
+	// used when requesting task input data.
+	Token string
 }
 
 // Context key type for storing UserInfo.
@@ -101,7 +109,7 @@ func (a *Authentication) Interceptor(
 		subject := a.oidc.ParseJwtSubject(jwtString)
 		authorized = subject != ""
 		if authorized {
-			ctx = context.WithValue(ctx, UserInfoKey, &UserInfo{Username: subject})
+			ctx = context.WithValue(ctx, UserInfoKey, &UserInfo{Username: subject, Token: jwtString})
 		}
 	}
 

--- a/server/auth_oidc.go
+++ b/server/auth_oidc.go
@@ -203,11 +203,11 @@ func (c *OidcConfig) computeState(req *http.Request) string {
 	return hex.EncodeToString(b)[:10]
 }
 
-func (c *OidcConfig) ParseJwt(jwtString string) *jwt.Token {
+func (c *OidcConfig) ParseJwtSubject(jwtString string) string {
 	keySet, err := c.jwks.Get(context.Background(), c.remote.JwksURI)
 	if err != nil {
 		fmt.Printf("[WARN] Failed to retrieve JWKS key-set: %s", err)
-		return nil
+		return ""
 	}
 
 	token, err := jwt.ParseString(
@@ -219,14 +219,14 @@ func (c *OidcConfig) ParseJwt(jwtString string) *jwt.Token {
 
 	if err != nil {
 		fmt.Printf("[WARN] Provided JWT is not valid: %s.\n", err)
-		return nil
+		return ""
 	}
 
 	if !c.isJwtValid(&token) || !c.isJwtActive(jwtString) {
-		return nil
+		return ""
 	}
 
-	return &token
+	return token.Subject()
 }
 
 func (c *OidcConfig) isJwtValid(token *jwt.Token) bool {

--- a/tes/utils.go
+++ b/tes/utils.go
@@ -53,6 +53,9 @@ func Base64Decode(raw string) (*Task, error) {
 
 // ErrNotFound is returned when a task is not found.
 var ErrNotFound = errors.New("task not found")
+
+// ErrNotPermitted is returned when the owner of a task does not match the
+// current non-admin user.
 var ErrNotPermitted = errors.New("permission denied")
 
 // Shorthand for task views

--- a/tes/utils.go
+++ b/tes/utils.go
@@ -53,6 +53,7 @@ func Base64Decode(raw string) (*Task, error) {
 
 // ErrNotFound is returned when a task is not found.
 var ErrNotFound = errors.New("task not found")
+var ErrNotPermitted = errors.New("permission denied")
 
 // Shorthand for task views
 const (

--- a/website/content/docs/security/basic.md
+++ b/website/content/docs/security/basic.md
@@ -7,19 +7,25 @@ menu:
 ---
 # Basic Auth
 
-By default, a Funnel server allows open access to its API endpoints, but it 
-can be configured to require basic password authentication. To enable this, 
+By default, a Funnel server allows open access to its API endpoints, but it
+can be configured to require basic password authentication. To enable this,
 include users and passwords in your config file:
 
 ```yaml
 Server:
   BasicAuth:
+    - User: admin
+      Password: someReallyComplexSecret
+      Admin: true
     - User: funnel
       Password: abc123
 ```
 
+Note that users see only their tasks, by default, unless a user is explicitly marked as administrator.
+Administrative users can see and interact with the tasks of all users.
+
 If you are using BoltDB or Badger, the Funnel worker communicates to the server via gRPC
-so you will also need to configure the RPC client. 
+so you will also need to configure the RPC client.
 
 ```yaml
 RPCClient:
@@ -27,7 +33,7 @@ RPCClient:
   Password: abc123
 ```
 
-Make sure to properly protect the configuration file so that it's not readable 
+Make sure to properly protect the configuration file so that it's not readable
 by everyone:
 
 ```bash

--- a/website/content/docs/security/oauth2.md
+++ b/website/content/docs/security/oauth2.md
@@ -21,6 +21,8 @@ token is still active (i.e., no token invalidation before expiring).
 Optionally, Funnel can also validate the scope and audience claims to contain
 specific values.
 
+It is not possible to configure administrative users for the OAuth2 authentication mode.
+
 To enable JWT authentication, specify `OidcAuth` section in your config file:
 
 ```yaml


### PR DESCRIPTION
This PR provides the code for associating tasks with the users who create them, and restricting access to tasks based on whether the user is an administrator or the creator of the task. It also supports the scenario when there is no user-authentication: then the tasks have no owners and everyone can see tasks without owners. There are no API-changes due to this development.

Changes to databases should be backward compatible, except that existing tasks (without ownership) won't be visible to non-admin users. In the configuration file, it's now possible to specify that a user (under Basic authentication) is an administrator. It is not supported with OIDC. Related configuration and documentation files were also updated a bit.

For this feature, user authentication information is now stored in the request `Context` as `UserInfo({IsPublic bool, IsAdmin bool, Username string})`. Different database implementations get the `UserInfo` from the `Context` and evaluate task ownership, or store the username with a task (if `Username` is not empty).

Notes about database implementations:
1. Badger: tasks are stored under keys `tasks<taskId>` and their owners under keys `owners<taskId>`.
2. BoltDB: owners are stored in a separate bucket ("tasks-owner") where taskID (key) has the value of its owner (username).
3. Google Datastore: owner is stored with the task data
4. Amazon DynamoDB: owner is stored with the task data
5. ElasticSearch: owner is stored with the task data
6. MongoDB: owner is stored with the task data

During testing I realised that support for ElasticSearch, MongoDB, Datastore is quite old. For example, I had to use Mongo version 4 (latest is 8) for testing. ElasticSearch client library is at version 5 while ElasticSearch itself is at version 8. The successor of Google Datastore is Google Firestore... I did not go into upgrading but it's good to bear in mind that Badger and BoltDB are probably the most convenient to use, at the moment.

Just in case, here is a reference that the CI pipeline was successful:
https://github.com/mrtamm/funnel-gdi/actions/runs/11291323700
 