### PR TITLE
Add continuous update of k8s job logs

### DIFF
--- a/config/kubernetes-executor-template.yaml
+++ b/config/kubernetes-executor-template.yaml
@@ -16,8 +16,17 @@ spec:
         image: {{.Image}}
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: {{.Command}}
+        args: 
+          - "{{.Command}}"
         workingDir: {{.Workdir}}
+        {{if len .Env}}
+        env:
+        {{range $key, $value := .Env}}
+        - name: {{$key}}
+          value: {{$value}}
+        {{end}}
+        {{end}}
+
         resources:
           requests:
             cpu: {{if ne .Cpus 0 -}}{{.Cpus}}{{ else }}{{"100m"}}{{end}}

--- a/worker/kubernetes.go
+++ b/worker/kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"text/template"
 	"time"
 
@@ -43,13 +44,17 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 		command = append(command, "<", kcmd.StdinFile)
 	}
 
+	joinedCommand := strings.Join(command, " ")
+	escapedCommand := strings.ReplaceAll(joinedCommand, `"`, `\"`)
+
 	var buf bytes.Buffer
 	err = tpl.Execute(&buf, map[string]interface{}{
 		"TaskId":    taskId,
 		"JobId":     kcmd.JobId,
 		"Namespace": kcmd.Namespace,
 		"Image":     kcmd.Image,
-		"Command":   command,
+		"Command":   escapedCommand,
+		"Env":       kcmd.Env,
 		"Workdir":   kcmd.Workdir,
 		"Volumes":   kcmd.Volumes,
 		"Cpus":      kcmd.Resources.CpuCores,

--- a/worker/kubernetes.go
+++ b/worker/kubernetes.go
@@ -87,39 +87,66 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 	_, err = client.Create(ctx, job, metav1.CreateOptions{})
 
 	if err != nil {
-		return fmt.Errorf("creating job: %v", err)
+		return fmt.Errorf("error while creating job: %v", err)
 	}
 
-	waitForJobFinish(ctx, client, metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s-%d", taskId, kcmd.JobId)})
-
-	pods, err := clientset.CoreV1().Pods(kcmd.Namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s-%d", taskId, kcmd.JobId)})
+	err = waitForJobPodStart(ctx, kcmd.Namespace, fmt.Sprintf("%s-%d", taskId, kcmd.JobId))
 	if err != nil {
-		return err
+		return fmt.Errorf("error while waiting for job pod to start: %v", err)
 	}
 
-	for _, v := range pods.Items {
-		req := clientset.CoreV1().Pods(kcmd.Namespace).GetLogs(v.Name, &corev1.PodLogOptions{})
-		podLogs, err := req.Stream(ctx)
+	go kcmd.streamLogs()
 
-		if err != nil {
-			return err
-		}
-
-		defer podLogs.Close()
-		buf := new(bytes.Buffer)
-		_, err = io.Copy(buf, podLogs)
-		if err != nil {
-			return err
-		}
-
-		var bytes = buf.Bytes()
-		_, err = kcmd.Stdout.Write(bytes)
-		if err != nil {
-			return err
-		}
+	err = waitForJobFinish(ctx, client, metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s-%d", taskId, kcmd.JobId)})
+	if err != nil {
+		return fmt.Errorf("error while waiting for job to finish: %v", err)
 	}
 
 	return nil
+}
+
+func (kcmd KubernetesCommand) streamLogs() {
+	clientset, err := getKubernetesClientset()
+	if err != nil {
+		fmt.Println("Error while getting kubernetes clientset: ", err)
+		return
+	}
+
+	pods, err := clientset.CoreV1().Pods(kcmd.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s-%d", kcmd.TaskId, kcmd.JobId)})
+	if err != nil {
+		fmt.Println("Error while getting pods: ", err)
+		return
+	}
+
+	pod := pods.Items[0]
+	req := clientset.CoreV1().Pods(kcmd.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Follow: true})
+	stream, err := req.Stream(context.TODO())
+
+	if err != nil {
+		fmt.Println("Error while opening log stream: ", err)
+		return
+	}
+
+	for {
+		buf := make([]byte, 512)
+		numBytes, err := stream.Read(buf)
+		if err != nil {
+			if err == io.EOF {
+				fmt.Printf("Pod log stream closed.\n")
+				return
+			}
+
+			fmt.Printf("Error while reading logs for pod: %v\n", err)
+			return
+		}
+
+		_, err = kcmd.Stdout.Write(buf[:numBytes])
+
+		if err != nil {
+			fmt.Printf("Error while writing logs: %v\n", err)
+			return
+		}
+	}
 }
 
 // Deletes the job running the task.
@@ -137,36 +164,62 @@ func (kcmd KubernetesCommand) Stop() error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("deleting job: %v", err)
+		return fmt.Errorf("error while deleting job: %v", err)
 	}
 
 	return nil
 }
 
-// Waits until the job finishes
-func waitForJobFinish(ctx context.Context, client batchv1.JobInterface, listOptions metav1.ListOptions) {
+func waitForJobPodStart(ctx context.Context, namespace string, jobName string) error {
+	clientset, err := getKubernetesClientset()
+	if err != nil {
+		return err
+	}
+
 	ticker := time.NewTicker(10 * time.Second)
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
+		case <-ticker.C:
+			pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s", jobName)})
+
+			if err != nil {
+				return err
+			}
+
+			if len(pods.Items) > 0 {
+				return nil
+			}
+		}
+	}
+}
+
+// Waits until the job finishes
+func waitForJobFinish(ctx context.Context, client batchv1.JobInterface, listOptions metav1.ListOptions) error {
+	ticker := time.NewTicker(10 * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
 		case <-ticker.C:
 			jobs, err := client.List(ctx, listOptions)
 
 			if err != nil {
-				return
+				return err
 			}
 
 			if len(jobs.Items) == 0 {
 				// Should not happen
-				return
+				return fmt.Errorf("job not found")
 			}
 
 			// There should be always only one job
 			job := jobs.Items[0]
 			if job.Status.Succeeded > 0 || job.Status.Failed > 0 {
-				return
+				return nil
 			}
 		}
 	}

--- a/worker/kubernetes.go
+++ b/worker/kubernetes.go
@@ -13,9 +13,9 @@ import (
 	v1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	batchv1 "k8s.io/client-go/kubernetes/typed/batch/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -97,10 +97,13 @@ func (kcmd KubernetesCommand) Run(ctx context.Context) error {
 
 	go kcmd.streamLogs()
 
-	err = waitForJobFinish(ctx, client, metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s-%d", taskId, kcmd.JobId)})
+	watcher, err := client.Watch(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("job-name=%s-%d", taskId, kcmd.JobId)})
 	if err != nil {
-		return fmt.Errorf("error while waiting for job to finish: %v", err)
+		return fmt.Errorf("error while watching job: %v", err)
 	}
+	defer watcher.Stop()
+
+	waitForJobFinish(ctx, watcher)
 
 	return nil
 }
@@ -127,25 +130,13 @@ func (kcmd KubernetesCommand) streamLogs() {
 		return
 	}
 
-	for {
-		buf := make([]byte, 512)
-		numBytes, err := stream.Read(buf)
-		if err != nil {
-			if err == io.EOF {
-				fmt.Printf("Pod log stream closed.\n")
-				return
-			}
+	defer stream.Close()
 
-			fmt.Printf("Error while reading logs for pod: %v\n", err)
-			return
-		}
+	_, err = io.Copy(kcmd.Stdout, stream)
 
-		_, err = kcmd.Stdout.Write(buf[:numBytes])
-
-		if err != nil {
-			fmt.Printf("Error while writing logs: %v\n", err)
-			return
-		}
+	if err != nil {
+		fmt.Println("Error while streaming logs: ", err)
+		return
 	}
 }
 
@@ -197,30 +188,20 @@ func waitForJobPodStart(ctx context.Context, namespace string, jobName string) e
 }
 
 // Waits until the job finishes
-func waitForJobFinish(ctx context.Context, client batchv1.JobInterface, listOptions metav1.ListOptions) error {
-	ticker := time.NewTicker(10 * time.Second)
-
+func waitForJobFinish(ctx context.Context, watcher watch.Interface) {
 	for {
 		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			jobs, err := client.List(ctx, listOptions)
+		case event := <-watcher.ResultChan():
+			job := event.Object.(*v1.Job)
 
-			if err != nil {
-				return err
-			}
-
-			if len(jobs.Items) == 0 {
-				// Should not happen
-				return fmt.Errorf("job not found")
-			}
-
-			// There should be always only one job
-			job := jobs.Items[0]
 			if job.Status.Succeeded > 0 || job.Status.Failed > 0 {
-				return nil
+				return
+			} else if event.Type == watch.Deleted {
+				return
 			}
+
+		case <-ctx.Done():
+			return
 		}
 	}
 }


### PR DESCRIPTION
This PR allows the Kubernetes executor to read logs from the worker jobs continuously. Until now, the logs were updated only once when the job finished. 