### PR TITLE
Simplified file-retrieval support using HTSGET and SDA protocols

### DIFF
--- a/config/default-config.yaml
+++ b/config/default-config.yaml
@@ -398,7 +398,16 @@ FTPStorage:
   User: "anonymous"
   Password: "anonymous"
 
+# When HTSGETStorage.ServiceURL (e.g. 'http://my.htsget.svc/') is a valid URL,
+# input-file URL with prefix "htsget://{reads|variants}/" becomes supported.
+# Only one HTSGET-service can be referenced.
 HTSGETStorage:
-  Disabled: false
-  Protocol: https
+  ServiceURL:
+  Timeout: 30s
+
+# When SDAStorage.ServiceURL is a valid URL (e.g. 'https://my.sda.svc/'),
+# input-file URL with prefix "sda://" becomes supported.
+# Only one SDA-service can be referenced.
+SDAStorage:
+  ServiceURL:
   Timeout: 30s

--- a/server/tes.go
+++ b/server/tes.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/ohsu-comp-bio/funnel/events"
 	"github.com/ohsu-comp-bio/funnel/logger"
@@ -33,9 +35,12 @@ type TaskService struct {
 // CreateTask provides an HTTP/gRPC endpoint for creating a task.
 // This is part of the TES implementation.
 func (ts *TaskService) CreateTask(ctx context.Context, task *tes.Task) (*tes.CreateTaskResponse, error) {
-
 	if err := tes.InitTask(task, true); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if err := ReplaceInputBearerToken(ctx, task); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if err := ts.Event.WriteEvent(ctx, events.NewTaskCreated(task)); err != nil {
@@ -108,4 +113,32 @@ func (ts *TaskService) GetServiceInfo(ctx context.Context, info *tes.ServiceInfo
 	}
 
 	return resp, nil
+}
+
+func ReplaceInputBearerToken(ctx context.Context, task *tes.Task) error {
+	userInfo, ok := ctx.Value(UserInfoKey).(*UserInfo)
+	noToken := !ok || userInfo.Token == ""
+
+	for _, input := range task.Inputs {
+		if !strings.HasPrefix(input.Url, "sda://") &&
+			!strings.HasPrefix(input.Url, "htsget://") ||
+			strings.Contains(input.Url, "#") {
+			continue
+		}
+		if noToken {
+			scheme, _, _ := strings.Cut(input.Url, "://")
+			if scheme == "htsget" {
+				continue
+			}
+			return errors.New("Task input from SDA requires a Bearer token " +
+				"to be used for fetching the data, however, current " +
+				"authentication-context has no information about the token " +
+				"to use. If necessary, please provide an explicit Bearer " +
+				"token in the URL right after the hash-sign ('#'): " +
+				"sda://dataset-id/file/path#bearer-token")
+		}
+		input.Url = input.Url + "#" + userInfo.Token
+	}
+
+	return nil
 }

--- a/storage/crypt4gh/decrypt.go
+++ b/storage/crypt4gh/decrypt.go
@@ -14,7 +14,7 @@ import (
 
 // Handles Crypt4gh decryption context per source stream.
 type Crypt4gh struct {
-	keyPair               *Crypt4ghKeyPair
+	keyPair               *KeyPair
 	stream                io.Reader
 	headerPacketCount     uint32
 	headerPacketProcessed uint32

--- a/storage/htsget_test.go
+++ b/storage/htsget_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestHTSGET(t *testing.T) {
 	invalidUrl := "https://example.org"
-	validUrl := "htsget://bearer:token@example.org"
+	validUrls := []string{"htsget://reads/file", "htsget://variants/file"}
 
 	store, err := NewHTSGET(config.HTSGETStorage{})
 	if err != nil {
@@ -23,28 +23,31 @@ func TestHTSGET(t *testing.T) {
 	}
 
 	// Correct protocol results in some unsupported operations (except GET)
-	ops = store.UnsupportedOperations(validUrl)
-	if ops.Stat == nil || ops.Join == nil || ops.List == nil || ops.Put == nil {
-		t.Error("Some non-supported operations were permitted for an HTSGET URL")
-	} else if ops.Get != nil {
-		t.Error("GET operation was not permitted for an HTSGET URL", err)
-	}
+	for _, validUrl := range validUrls {
+		ops = store.UnsupportedOperations(validUrl)
 
-	// Verifying unsupported operations
+		if ops.Stat == nil || ops.Join == nil || ops.List == nil || ops.Put == nil {
+			t.Error("Some non-supported operations were permitted for an HTSGET URL")
+		} else if ops.Get != nil {
+			t.Error("GET operation was not permitted for an HTSGET URL", err)
+		}
 
-	if _, err = store.Stat(context.Background(), validUrl); err == nil {
-		t.Error("Stat call should have failed for HTSGET")
-	}
+		// Verifying unsupported operations
 
-	if _, err = store.Join(validUrl, ""); err == nil {
-		t.Error("Join call should have failed for HTSGET")
-	}
+		if _, err = store.Stat(context.Background(), validUrl); err == nil {
+			t.Error("Stat call should have failed for HTSGET")
+		}
 
-	if _, err = store.List(context.Background(), validUrl); err == nil {
-		t.Error("List call should have failed for HTSGET")
-	}
+		if _, err = store.Join(validUrl, ""); err == nil {
+			t.Error("Join call should have failed for HTSGET")
+		}
 
-	if _, err = store.Put(context.Background(), validUrl, "path"); err == nil {
-		t.Error("Put call should have failed for HTSGET")
+		if _, err = store.List(context.Background(), validUrl); err == nil {
+			t.Error("List call should have failed for HTSGET")
+		}
+
+		if _, err = store.Put(context.Background(), validUrl, "path"); err == nil {
+			t.Error("Put call should have failed for HTSGET")
+		}
 	}
 }

--- a/storage/mux.go
+++ b/storage/mux.go
@@ -100,6 +100,14 @@ func NewMux(conf config.Config) (*Mux, error) {
 		mux.Backends = append(mux.Backends, htsget)
 	}
 
+	if conf.SDAStorage.Valid() {
+		sda, err := NewSDA(conf.SDAStorage)
+		if err != nil {
+			return mux, fmt.Errorf("failed to config SDA storage backend: %s", err)
+		}
+		mux.Backends = append(mux.Backends, sda)
+	}
+
 	return mux, nil
 }
 

--- a/storage/sda.go
+++ b/storage/sda.go
@@ -1,0 +1,207 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	urllib "net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ohsu-comp-bio/funnel/config"
+	"github.com/ohsu-comp-bio/funnel/storage/crypt4gh"
+	"github.com/ohsu-comp-bio/funnel/util/fsutil"
+)
+
+// SDA (sensitive data archive) provides read-access to public URLs.
+// SDA URLs need to provided in Funnel tasks as
+// `sda://dataset-id/path/to/dataset/file.c4gh`
+// The Bearer token is implicitly taken from a task request and used when
+// requesting a file from SDA.
+type SDA struct {
+	conf   config.SDAStorage
+	client *http.Client
+}
+
+// NewSDA creates a new SDA-client instance based on the provided configuration.
+func NewSDA(conf config.SDAStorage) (*SDA, error) {
+	client := &http.Client{
+		Timeout: time.Duration(conf.Timeout),
+	}
+	return &SDA{conf, client}, nil
+}
+
+// UnsupportedOperations describes which operations (Get, Put, etc) are not
+// supported for the given URL.
+func (b *SDA) UnsupportedOperations(url string) UnsupportedOperations {
+	if !strings.HasPrefix(url, "sda://") {
+		return AllUnsupported(&ErrUnsupportedProtocol{"sdaStorage"})
+	}
+	return UnsupportedOperations{
+		Join: fmt.Errorf("sdaStorage: Join operation is not supported"),
+		List: fmt.Errorf("sdaStorage: List operation is not supported"),
+		Stat: fmt.Errorf("sdaStorage: Stat operation is not supported"),
+		Put:  fmt.Errorf("sdaStorage: Put operation is not supported"),
+	}
+}
+
+// Join a directory URL with a subpath. Not supported with SDA.
+func (b *SDA) Join(url, path string) (string, error) {
+	return "", fmt.Errorf("sdaStorage: Join operation is not supported")
+}
+
+// List a directory. Calling List on a File is an error. Not supported with SDA.
+func (b *SDA) List(ctx context.Context, url string) ([]*Object, error) {
+	return nil, fmt.Errorf("sdaStorage: List operation is not supported")
+}
+
+// Not supported with SDA.
+func (b *SDA) Put(ctx context.Context, url, path string) (*Object, error) {
+	return nil, fmt.Errorf("sdaStorage: Put operation is not supported")
+}
+
+// Stat returns information about the object in SDA.
+func (s *SDA) Stat(ctx context.Context, url string) (*Object, error) {
+	resp, err := s.doRequest(ctx, "HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return toObject(resp, url), nil
+}
+
+// Get operation copies a file from a given URL to the host path.
+//
+// If configuration specifies sending a public key, the received content will
+// be also decrypted locally before writing to the file.
+func (s *SDA) Get(ctx context.Context, url, path string) (*Object, error) {
+	keys, err := crypt4gh.ResolveKeyPair()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.doRequest(ctx, "GET", url, keys)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err = downloadToFile(ctx, resp, path, keys); err != nil {
+		return nil, err
+	}
+
+	return toObject(resp, path), nil
+}
+
+// List a directory. Calling List on a File is an error. Not supported with SDA.
+func (s *SDA) resolveUrl(sdaUrl string) (httpUrl string, token string, err error) {
+	// Extract the Bearer token after the last '#':
+	if pos := strings.LastIndex(sdaUrl, "#"); pos > 0 {
+		token = sdaUrl[pos+1:]
+		sdaUrl = sdaUrl[:pos]
+	}
+
+	actual, err := urllib.Parse(s.conf.ServiceURL)
+	if err != nil {
+		return
+	}
+
+	// Extract possible query paramaters – they would not go to path:
+	if prefix, query, found := strings.Cut(sdaUrl, "?"); found {
+		actual.RawQuery = query
+		sdaUrl = prefix
+	}
+
+	// Append the provided path (e.g. 'variants/file-path'):
+	path := sdaUrl[len("sda://"):]
+	if strings.HasSuffix(path, ".c4gh") {
+		path = "/s3-encrypted/" + path
+	} else {
+		path = "/s3/" + path
+	}
+	actual.Path = strings.TrimSuffix(actual.Path, "/") + path
+
+	httpUrl = actual.String()
+	return httpUrl, token, nil
+}
+
+func (s *SDA) doRequest(
+	ctx context.Context,
+	method string,
+	sdaUrl string,
+	keys *crypt4gh.KeyPair,
+) (resp *http.Response, err error) {
+
+	url, token, err := s.resolveUrl(sdaUrl)
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		err = fmt.Errorf("sdaStorage: creating %s request: %s", method, err)
+		return
+	}
+
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	if strings.Contains(req.URL.Path, "/s3-encrypted/"); keys != nil {
+		req.Header.Set("Client-Public-Key", keys.EncodePublicKeyBase64())
+	}
+
+	resp, err = s.client.Do(req)
+	if err != nil {
+		err = fmt.Errorf("sdaStorage: executing %s request: %s", method, err)
+	} else if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Request.Body)
+		resp.Body.Close()
+		err = fmt.Errorf("sdaStorage: %s request returned status code %d: %s",
+			method, resp.StatusCode, string(body))
+	}
+
+	return
+}
+
+func downloadToFile(
+	ctx context.Context,
+	resp *http.Response,
+	path string,
+	keys *crypt4gh.KeyPair,
+) error {
+	dest, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("sdaStorage: creating host file: %s", err)
+	}
+	defer dest.Close()
+
+	var stream io.Reader = resp.Body
+	if resp.Request.Header.Get("Client-Public-Key") != "" {
+		stream, err = keys.Decrypt(stream)
+		if err != nil {
+			return fmt.Errorf(
+				"sdaStorage: decrypting received payload data: %s", err)
+		}
+	}
+
+	if _, err = io.Copy(dest, fsutil.Reader(ctx, stream)); err != nil {
+		return fmt.Errorf("sdaStorage: copying file: %s", err)
+	}
+
+	return nil
+}
+
+func toObject(resp *http.Response, path string) *Object {
+	modtime, _ := http.ParseTime(resp.Header.Get("Last-Modified"))
+	etag := resp.Header.Get("ETag")
+
+	return &Object{
+		URL:          resp.Request.RequestURI,
+		Name:         path,
+		Size:         resp.ContentLength,
+		LastModified: modtime,
+		ETag:         etag,
+	}
+}

--- a/storage/sda.go
+++ b/storage/sda.go
@@ -148,7 +148,7 @@ func (s *SDA) doRequest(
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	if strings.Contains(req.URL.Path, "/s3-encrypted/"); keys != nil {
+	if strings.Contains(req.URL.Path, "/s3-encrypted/") && keys != nil {
 		req.Header.Set("Client-Public-Key", keys.EncodePublicKeyBase64())
 	}
 
@@ -198,7 +198,7 @@ func toObject(resp *http.Response, path string) *Object {
 	etag := resp.Header.Get("ETag")
 
 	return &Object{
-		URL:          resp.Request.RequestURI,
+		URL:          resp.Request.URL.String(),
 		Name:         path,
 		Size:         resp.ContentLength,
 		LastModified: modtime,

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -21,7 +21,8 @@ func TestStorageWithConfig(t *testing.T) {
 		Swift:         config.SwiftStorage{Disabled: true},
 		HTTPStorage:   config.HTTPStorage{Disabled: true},
 		FTPStorage:    config.FTPStorage{Disabled: true},
-		HTSGETStorage: config.HTSGETStorage{Disabled: true},
+		HTSGETStorage: config.HTSGETStorage{},
+		SDAStorage:    config.SDAStorage{},
 	}
 
 	sc, err := NewMux(c)
@@ -66,7 +67,8 @@ func TestStorageWithConfig(t *testing.T) {
 			RegionName: "fakeregion",
 		},
 		HTTPStorage:   config.HTTPStorage{Disabled: false},
-		HTSGETStorage: config.HTSGETStorage{Disabled: true},
+		HTSGETStorage: config.HTSGETStorage{},
+		SDAStorage:    config.SDAStorage{},
 	}
 	sc, err = NewMux(c)
 	if err != nil {

--- a/website/content/docs/storage/sda.md
+++ b/website/content/docs/storage/sda.md
@@ -1,0 +1,86 @@
+---
+title: SDA Storage
+menu:
+  main:
+    parent: Storage
+---
+
+# Sensitive Data Archive (SDA) Storage
+
+Funnel supports content-retrieval from an [SDA-Download][sda]-compatible API.
+This is a service with an HTTP-based REST-API with some additions:
+
+1. The request must be authenticated using a Bearer token, a JSON Web Token to
+   be validated by SDA, checking it would contain a valid GA4GH Visa permitting
+   access to the targeted dataset.
+2. If the targeted file is encrypted using [Crypt4gh](crypt4gh) (it has ".c4gh"
+   extension), the client (e.g. Funnel) needs to send its public key so that
+   SDA would reencrypt the file header, which would enable to obtain the cipher
+   key from the header using its private key. Funnel makes the file accessible
+   to the computation task without encryption.
+
+The task input file URL needs to specify `sda` as the resource protocol.
+Funnel will extract path information from the specified URL and append it to
+the service URL specified in the Funnel configuration. The format of the input
+data URL is following:
+
+```
+sda://<dataset-id>/<resource/path>
+```
+
+For example: `sda://DATASET_2000/synthetic/sample.bam`
+
+
+If the service expects a `Bearer` (token) or `Basic` (username:password)
+authentication, it can be specified at the end of the URL right after the
+hash-sign (`#`). For example: `sda://dataset/file#jwt-token-here`.
+Note that when the task is submitted to Funnel using a valid `Bearer` token for
+user authentication, the same token will be automatically appended to the
+SDA URL, so the request to the SDA service would use the same token.
+Exception is when the URL already specifies the hash-sign (`#`) – then it won't
+be updated.
+
+Funnel sends its Crypt4gh public key in the header (`client-public-key`) of the
+request to the SDA service, when the requested file has ".c4gh" extension.
+
+For sensitive data, the deployment environment (server) should pay attention to
+restricting access to the Funnel's data directories, possibly having separate
+Funnel instances for different data-projects.
+
+SDA Storage configuration just requires a service URL to become active:
+
+```yaml
+SDAStorage:
+  ServiceURL: https://example.org:8443/sda/
+  Timeout: 30s
+```
+
+If the `ServiceUrl` is undefined, `sda` protocol will be disabled.
+
+### Example task
+
+```json
+{
+  "name": "Hello world",
+  "inputs": [{
+    "url": "sda://DATASET-2024-012345/variants/genome2341.vcf.gz",
+    "path": "/inputs/genome.vcf.gz"
+  }],
+  "outputs": [{
+    "url": "file:///results/line_count.txt",
+    "path": "/outputs/line_count.txt"
+  }],
+  "executors": [{
+    "image": "alpine",
+    "command": [
+      "sh",
+      "-c",
+      "zcat /inputs/genome.vcf.gz | wc -l"
+    ],
+    "stdout": "/outputs/line_count.txt"
+  }]
+}
+```
+
+[sda]: https://github.com/neicnordic/sensitive-data-archive/blob/main/sda-download/api/api.md
+[crypt4gh]: http://samtools.github.io/hts-specs/crypt4gh.pdf


### PR DESCRIPTION
Overview of changes:

1. Added support for file-retrieval using protocol: `sda://<dataset_id>/path/to/file`
   * Bearer token is implicitly re-used from the "create-task" request.
   * The "create-task" request without a Bearer token will fail immediately.
   * It is possible to provide explicit Bearer token at the end of the URL after hash-sign; for example: `sda://<dataset_id>/file#token-here`
   * Supports downloading both Crypt4gh files (over `/s3-encrypted/...` path; decrypting `*.c4gh` files locally) and decrypted files (over `/s3/...` path)
   * Configuration just specifies the ServiceURL for the SDA to be used.
2. Simplified support for file-retrieval using HTSGET `htsget://{reads|variants}/path/to/file-without-extension`
   * Bearer token is implicitly re-used from the "create-task" request.
   * The "create-task" request will NOT fail without a Bearer token or credentials. (HTSGET may support non-authenticated requests.)
   * It is possible to provide explicit _username:password_ or Bearer token at the end of the URL after hash-sign; for example: `htsget://.../file#user:pass`
   * Configuration just specifies the ServiceURL for the HTSGET to be used.
4. Refactored type names (simpler) in crypt4gh and htsget.
5. Updated documentation about HTSGET and SDA protocols.